### PR TITLE
adding custom search index to the chat api

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ This demo has been modified to add custom indexes. This allows the user to be ab
     a. Choose the branch you created.
     b. Enter a name for the index.
 1.  Start the workflow.
+1.  Once the workflow has run successfully, you can use it in your demo. Open a browser and go to the Open AI demo.
+1.  Open the `Developer Settings` panel.
+1.  In the `Search Index` field, add the name of the search index you created.
+1.  Close the `Developer Settings` panel.
+1.  Any API calls to `/chat` will now use the new search index.
+
+> Note: The `/ask` API has not yet been modified.
 
 #### Sharing Environments
 

--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -1,7 +1,7 @@
 import { AskRequest, AskResponse, ChatRequest } from "./models";
 
-const hostUrl = "https://app-backend-2j5yhqt6og32i.azurewebsites.net";
-//const hostUrl = "";
+//const hostUrl = "https://app-backend-2j5yhqt6og32i.azurewebsites.net";
+const hostUrl = "";
 export async function askApi(options: AskRequest): Promise<AskResponse> {
     const response = await fetch(`${hostUrl}/ask`, {
         method: "POST",
@@ -46,6 +46,7 @@ export async function chatApi(options: ChatRequest): Promise<AskResponse> {
                 retrieval_mode: options.overrides?.retrievalMode,
                 semantic_ranker: options.overrides?.semanticRanker,
                 semantic_captions: options.overrides?.semanticCaptions,
+                search_index: options.overrides?.searchIndex,
                 top: options.overrides?.top,
                 temperature: options.overrides?.temperature,
                 prompt_template: options.overrides?.promptTemplate,

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -17,6 +17,7 @@ export type AskRequestOverrides = {
     excludeCategory?: string;
     top?: number;
     temperature?: number;
+    searchIndex?: string;
     promptTemplate?: string;
     promptTemplatePrefix?: string;
     promptTemplateSuffix?: string;

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
 import { Checkbox, Panel, DefaultButton, TextField, SpinButton, Dropdown, IDropdownOption } from "@fluentui/react";
 import { SparkleFilled } from "@fluentui/react-icons";
 
@@ -15,7 +14,6 @@ import { SettingsButton } from "../../components/SettingsButton";
 import { ClearChatButton } from "../../components/ClearChatButton";
 
 const Chat = () => {
-    let { company = "BC" } = useParams();
     const [temperature, setTemperature] = useState(0.3);
     const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
     const [promptTemplate, setPromptTemplate] = useState<string>("");
@@ -24,6 +22,7 @@ const Chat = () => {
     const [useSemanticRanker, setUseSemanticRanker] = useState<boolean>(true);
     const [useSemanticCaptions, setUseSemanticCaptions] = useState<boolean>(false);
     const [excludeCategory, setExcludeCategory] = useState<string>("");
+    const [searchIndex, setSearchIndex] = useState<string>("");
     const [useSuggestFollowupQuestions, setUseSuggestFollowupQuestions] = useState<boolean>(false);
 
     const lastQuestionRef = useRef<string>("");
@@ -54,6 +53,7 @@ const Chat = () => {
                 overrides: {
                     promptTemplate: promptTemplate.length === 0 ? undefined : promptTemplate,
                     excludeCategory: excludeCategory.length === 0 ? undefined : excludeCategory,
+                    searchIndex: searchIndex.length === 0 ? undefined : searchIndex,
                     top: retrieveCount,
                     temperature: temperature,
                     retrievalMode: retrievalMode,
@@ -103,6 +103,10 @@ const Chat = () => {
 
     const onExcludeCategoryChanged = (_ev?: React.FormEvent, newValue?: string) => {
         setExcludeCategory(newValue || "");
+    };
+
+    const onSearchIndexChanged = (_ev?: React.FormEvent, newValue?: string) => {
+        setSearchIndex(newValue || "");
     };
 
     const onTemperatureChanged = (_ev?: React.FormEvent, newValue?: string) => {
@@ -241,6 +245,7 @@ const Chat = () => {
                     />
                     <TextField className={styles.chatSettingsSeparator} label="Exclude category" onChange={onExcludeCategoryChanged} />
                     <TextField className={styles.chatSettingsSeparator} label="Temperature" defaultValue={`${temperature}`} onChange={onTemperatureChanged} />
+                    <TextField className={styles.chatSettingsSeparator} label="Search Index" defaultValue={`${searchIndex}`} onChange={onSearchIndexChanged} />
                     <Checkbox
                         className={styles.chatSettingsSeparator}
                         checked={useSemanticRanker}


### PR DESCRIPTION
## Purpose
A custom search index allows us to create different search indexes per customer.  This way, the demo is fully tailored to their need.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

- Add an override in the Developer Settings UI
- Add the searchIndex to the AskRequestOverrides model
- Add the search_index to the api call to the backend
- Add the search_index retrieval from the api request in the backend def for /chat
- If there is a search_index override, create a new search client and attempt to use it 

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Open the browser to the Open AI demo
* Run the demo, choosing the healthcare question.
* The results should come back with a result.
* Open the Developer Settings and add a new search index, lets call it `test_a`
* Then rerun the healthcare question.  The result should fail since the index does not exist.
* Open the Developer Settings and add a search index called `test`
* Rerun the healthcare question.  The result should say that the search does not have any healthcare related data.
* Ask the question, 'What are the top areas for growth?'
* The result should show a response.

## Other Information
The `Ask a question` feature does not use the search index override yet.